### PR TITLE
Pull request - adding support for analyzer exporting.

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -526,11 +526,29 @@ class Saleae():
 
 
 	def get_analyzers(self):
-		raise NotImplementedError
-	def export_analyzers(self):
-		raise NotImplementedError
+		'''Return a list of analyzers currently in use, with indexes.'''
+		reply = self._cmd('GET_ANALYZERS')
+		self.analyzers = []
+		for line in reply.split('\n'):
+			if len(line):
+				analyzer_name = line.split(',')[0]
+				analyzer_index = int(line.split(',')[1])
+				self.analyzers.append((analyzer_name, analyzer_index))
+		return self.analyzers
+
+	def export_analyzer(self, analyzer_index, save_path):
+		'''Export analyzer index N and save to absolute path save_path. The analyzer must be finished processing'''
+		self._build('EXPORT_ANALYZER')
+		self._build(str(analyzer_index))
+		self._build(save_path)
+		resp = self._finish()
+
 	def is_analyzer_complete(self, analyzer_index):
-		raise NotImplementedError
+		'''check to see if analyzer with index N has finished processing.'''
+		self._build('IS_ANALYZER_COMPLETE')
+		self._build(str(analyzer_index))
+		resp = self._finish()
+		return resp.strip().upper() == 'TRUE'
 
 
 def demo(host='localhost', port=10429):


### PR DESCRIPTION
To export an analyzer's protocol results, the analyzer must be finished processing.
Analyzers are accessed by an analyzer index, which is returned from the function get_analyzers.
Those indexes are not guaranteed to be sequential or start at one.
The export location must exist, and the path must be absolute. ~/ home directory shortcuts will not work. Neither will %APPDATA% style variables.

The general process for exporting an analyzer:
capture data. wait for capture to finish processing.
call get_analyzers, record index of interest
wait in loop for analyzer to finish processing (call is_analyzer_complete with index)
call export_analyzer with the analyzer index and the parth
