### PR TITLE
[WIP] Python 2.7 Support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,7 @@ def readme():
 
 exec(open(os.path.join('saleae', 'version.py')).read())
 
-requires = [
-		'future',
-		'enum34',
-		]
+requires = ["enum34"]
 
 setup(
 		name='saleae',


### PR DESCRIPTION
This PR is intended to add support for Python 2.7. It is related to issue #5.

I haven't had a chance to test this out with actual hardware yet so I'm not certain that works.

Just opening up Logic and running the `demo()` function results in what appears to be a working demo script up until the point where it needs to wait for `is_processing_complete`. At that point Logic crashes and we get a CommandNAKedError. Something tells me this issue is with Logic though, or a change in the API and not the result of anything I've done here.

Testing with Python 3.4 on my same machine and with the same version of Logic results in the same outcome.

This PR also unfortunately includes a big blob of changes for converting whitespace. When I attempted to run saleae.py in Python3 the interpreter would not allow it due to mixed tabs and spaces. I converted all tabs into 4 spaces (in line with PEP-8). I didn't realize that the whole file was using tabs though, or I would have just changed my additions. Anyways, I can pull that out of the PR if you'd like it to be a bit more focused.

Also I'd recommend not merging this in until someone can test it out.
