### PR TITLE
Fix calling get_active_channels from export_data

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -467,7 +467,7 @@ class Saleae():
 		self._build(file_path_on_target_machine)
 		if (digital_channels is None) and (analog_channels is None):
 			self._build('all_channels')
-			analog_channels = self.get_active_channels(self)[1]
+			analog_channels = self.get_active_channels()[1]
 		else:
 			if digital_channels is not None and len(digital_channels):
 				self._build('digital_channels')


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "saleae/saleae.py", line 470, in export_data
    analog_channels = self.get_active_channels(self)[1]
TypeError: get_active_channels() takes exactly 1 argument (2 given)    
```
