### PR TITLE
get_active_channels: Handle TRUE response from device

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -370,6 +370,9 @@ class Saleae():
 
 		:returns: A 2-tuple of lists of integers, the active digital and analog channels respectively'''
 		channels = self._cmd('GET_ACTIVE_CHANNELS')
+		while ('TRUE' == channels):
+			time.sleep(0.1)
+			channels = self._cmd('GET_ACTIVE_CHANNELS')
 		msg = list(map(str.strip, channels.split(',')))
 		assert msg.pop(0) == 'digital_channels'
 		i = msg.index('analog_channels')


### PR DESCRIPTION
When calling get_active_channels, on the Logic Pro 8, there is a chance
that TRUE will be returned instead of the expected digital_channels.

without this check, the assert will crash out.

This occurs when changing the trigger of the channel after performing a
capture.

Signed-off-by: Malcolm Prinn malcolm.prinn@intel.com
