### PR TITLE
get_active_channels: Handle 'TRUE' or blank response

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -452,7 +452,7 @@ class Saleae():
 		channels = self._cmd('GET_ACTIVE_CHANNELS')
 		# Work around possible bug in Logic8
 		# https://github.com/ppannuto/python-saleae/pull/19
-		while ('TRUE' == channels):
+		while not channels.startswith('digital_channels'):
 			time.sleep(0.1)
 			channels = self._cmd('GET_ACTIVE_CHANNELS')
 		msg = list(map(str.strip, channels.split(',')))


### PR DESCRIPTION
Occasionally, on the Logic Pro 8, the response to the
'GET_ACTIVE_CHANNELS' command will return either 'TRUE' or an empty
string.

This occurs when changing the trigger of the channel after performing a
capture.

Signed-off-by: Malcolm Prinn malcolm.prinn@intel.com
