### PR TITLE
EXPORT_ANALYZER data response

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -815,7 +815,7 @@ class Saleae():
 				self.analyzers.append((analyzer_name, analyzer_index))
 		return self.analyzers
 
-	def export_analyzer(self, analyzer_index, save_path, wait_for_processing=True):
+	def export_analyzer(self, analyzer_index, save_path, wait_for_processing=True, data_response=False):
 		'''Export analyzer index N and save to absolute path save_path. The analyzer must be finished processing'''
 		if wait_for_processing:
 			while not self.is_analyzer_complete(analyzer_index):
@@ -823,7 +823,10 @@ class Saleae():
 		self._build('EXPORT_ANALYZER')
 		self._build(str(analyzer_index))
 		self._build(save_path)
+		if data_response:
+			self._build('data_response')  # any old extra parameter can be used
 		resp = self._finish()
+		return resp if data_response else None
 
 	def is_analyzer_complete(self, analyzer_index):
 		'''check to see if analyzer with index N has finished processing.'''


### PR DESCRIPTION
Page 22 of [Logic Socket API Users Guide](https://github.com/saleae/SaleaeSocketApi/blob/master/Doc/Logic%20Socket%20API%20Users%20Guide.pdf) details an optional third parameter to have the analyzer data returned in the socket response.

> Add a third, optional parameter to have the results piped back through the TCP socket to you.

This change exposes that with a kwarg `data_response=<boolean>` to enable that feature.

I'm currently using this to receive two Async Serial decodes (RX and TX) and merge them into a single CSV where each RX and TX are a column, and everything is sorted by timestamp.
