### PR TITLE
set_active_channels: ','.join() channel lists before _finish()

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -479,11 +479,13 @@ class Saleae():
 
 		self._build('SET_ACTIVE_CHANNELS')
 		if digital_no > 0:
+                        digital_ch = ['{0:d}'.format(ch) for ch in digital]
 			self._build('digital_channels')
-			self._build(['{0:d}'.format(ch) for ch in digital])
+			self._build(','.join(digital_ch))
 		if analog_no > 0:
+                        analog_ch = ['{0:d}'.format(ch) for ch in analog]
 			self._build('analog_channels')
-			self._build(['{0:d}'.format(ch) for ch in analog])
+			self._build(','.join(analog_ch))
 		self._finish()
 
 	def reset_active_channels(self):


### PR DESCRIPTION
See: Issue #22 

_finish() joins the built list before sending to Logic via _cmd()
'set_active_channels' calls _build() on a list object, and therefore fails the join.

I have fixed this issue by joining the channel list before passing to _build. Seems to work fine for me now.
