### PR TITLE
Issue #23: Fix a problem building strings from lists

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -94,7 +94,7 @@ class Saleae():
 
 	def _build(self, s):
 		'''Convenience method for building up a command to send'''
-		if type(s) is list:
+		if isinstance(s, list):
 			self._to_send.extend(s)
 		else:
 			self._to_send.append(s)


### PR DESCRIPTION
Using type(list) doesn't work for all possible types and isinstance() is a safer way to check this. This was failing with Python 2.7.10 when passing a list of specific digital channels to the _build() routine in export_data2() but could also happen in other places in the code.
