### PR TITLE
Fix the get_active_channels function for old Logic8's

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -449,6 +449,12 @@ class Saleae():
 		>>> s.get_active_channels()
 		([0, 1, 2, 3], [0])
 		'''
+		# If an old Logic8 is connected this command does not work, but all 8
+		# digital channels are always active so return that.
+		device = self.get_active_device()
+		if device.type == "LOGIC_DEVICE":
+			return range(8), []
+
 		channels = self._cmd('GET_ACTIVE_CHANNELS')
 		# Work around possible bug in Logic8
 		# https://github.com/ppannuto/python-saleae/pull/19


### PR DESCRIPTION
The old Logic8 devices do not support the get_active_channels command. On these
devices there are always only 8 active digital channels so we should just return
that otherwise the export_data and export_data2 code will fail to work.
