### PR TITLE
get_connected_devices : Handle 'TRUE' response from device

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -401,6 +401,10 @@ class Saleae():
 		[<saleae.ConnectedDevice #1 LOGIC_4_DEVICE Logic 4 (...) **ACTIVE**>, <saleae.ConnectedDevice #2 LOGIC_8_DEVICE Logic 8 (...)>, <saleae.ConnectedDevice #3 LOGIC_PRO_8_DEVICE Logic Pro 8 (...)>, <saleae.ConnectedDevice #4 LOGIC_PRO_16_DEVICE Logic Pro 16 (...)>]
 		'''
 		devices = self._cmd('GET_CONNECTED_DEVICES')
+		while ('TRUE' == devices):
++			time.sleep(0.1)
++			devices = self._cmd('GET_CONNECTED_DEVICES')
+
 		self.connected_devices = []
 		for dev in devices.split('\n')[:-1]:
 			active = False

--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -402,8 +402,8 @@ class Saleae():
 		'''
 		devices = self._cmd('GET_CONNECTED_DEVICES')
 		while ('TRUE' == devices):
-+			time.sleep(0.1)
-+			devices = self._cmd('GET_CONNECTED_DEVICES')
+			time.sleep(0.1)
+			devices = self._cmd('GET_CONNECTED_DEVICES')
 
 		self.connected_devices = []
 		for dev in devices.split('\n')[:-1]:


### PR DESCRIPTION
Much like user mprinn's commit (975896922760ec36594df7237a3986f47808f869), when changing the trigger type, the command 'GET_CONNECTED_DEVICES' only returns 'TRUE' for saleae Logic Pro 16 instead of a list of connected devices.

Used in : set_trigger_one_channel -> get_active_channels -> get_active_device -> get_connected_devices, after a capture.
