### PR TITLE
get_connected_devices: Sturdier handling response

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -401,7 +401,7 @@ class Saleae():
 		[<saleae.ConnectedDevice #1 LOGIC_4_DEVICE Logic 4 (...) **ACTIVE**>, <saleae.ConnectedDevice #2 LOGIC_8_DEVICE Logic 8 (...)>, <saleae.ConnectedDevice #3 LOGIC_PRO_8_DEVICE Logic Pro 8 (...)>, <saleae.ConnectedDevice #4 LOGIC_PRO_16_DEVICE Logic Pro 16 (...)>]
 		'''
 		devices = self._cmd('GET_CONNECTED_DEVICES')
-		while ('TRUE' == devices):
+		while ('' == devices or not devices[0].isdigit()):
 			time.sleep(0.1)
 			devices = self._cmd('GET_CONNECTED_DEVICES')
 

--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -401,6 +401,7 @@ class Saleae():
 		[<saleae.ConnectedDevice #1 LOGIC_4_DEVICE Logic 4 (...) **ACTIVE**>, <saleae.ConnectedDevice #2 LOGIC_8_DEVICE Logic 8 (...)>, <saleae.ConnectedDevice #3 LOGIC_PRO_8_DEVICE Logic Pro 8 (...)>, <saleae.ConnectedDevice #4 LOGIC_PRO_16_DEVICE Logic Pro 16 (...)>]
 		'''
 		devices = self._cmd('GET_CONNECTED_DEVICES')
+		# command response is sometimes not the expected one : a non-empty string starting with a digit (index) 
 		while ('' == devices or not devices[0].isdigit()):
 			time.sleep(0.1)
 			devices = self._cmd('GET_CONNECTED_DEVICES')


### PR DESCRIPTION
Response to command 'GET_CONNECTED_DEVICES' can vary from '' to 'True\n' or a previous command response. This is an improved and sturdier version of commit 288d8ef676e41551d9e18da7a85281ac067c4651
