### PR TITLE
Added a DIGITAL_ONLY and ANALOG_ONLY options to the export_data2()

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -860,6 +860,10 @@ class Saleae():
 			# implementation)
 			if digital_channels is not None and len(digital_channels) and analog_channels is not None and len(analog_channels):
 				self._build('ANALOG_AND_DIGITAL')
+			elif digital_channels is not None and len(digital_channels):
+				self._build('DIGITAL_ONLY')
+			elif analog_channels is not None and len(analog_channels):
+				self._build('ANALOG_ONLY')
 
 			# Add in the channels
 			if digital_channels is not None and len(digital_channels):


### PR DESCRIPTION
Otherwise, export of the specified channels didn't work on my Saleae Logic Pro 8 with 1.2.12 software version.