### PR TITLE
Additional investigations of the export process

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -842,6 +842,10 @@ class Saleae():
 			raise ValueError('File path must be absolute')
 		# Fix windows path if needed
 		file_path_on_target_machine.replace('\\', '/')
+		
+		#Get active channels
+		digital_active, analog_active = self.get_active_channels()
+		
 		self._build('EXPORT_DATA2')
 		self._build(file_path_on_target_machine)
 
@@ -858,12 +862,13 @@ class Saleae():
 			# the fact that only ANALOG_AND_DIGITAL is printed and never
 			# DIGITAL_ONLY or ANALOG_ONLY (according to Saleae C#
 			# implementation)
-			if digital_channels is not None and len(digital_channels) and analog_channels is not None and len(analog_channels):
-				self._build('ANALOG_AND_DIGITAL')
-			elif digital_channels is not None and len(digital_channels):
-				self._build('DIGITAL_ONLY')
-			elif analog_channels is not None and len(analog_channels):
-				self._build('ANALOG_ONLY')
+			if len(digital_active) and len(analog_active):
+				if digital_channels is not None and len(digital_channels) and analog_channels is not None and len(analog_channels):
+					self._build('ANALOG_AND_DIGITAL')
+				elif digital_channels is not None and len(digital_channels):
+					self._build('DIGITAL_ONLY')
+				elif analog_channels is not None and len(analog_channels):
+					self._build('ANALOG_ONLY')
 
 			# Add in the channels
 			if digital_channels is not None and len(digital_channels):


### PR DESCRIPTION
I made an additional investigation of the export process and here is my results. The main conclusion is - we should take into account what channels are **Active** and what channels are asked to **Export**. Only this way we can choose the right combination of options. 

NOTE: Tested only on my Saleae Logic Pro 8 with 1.2.12 software version.

## `export_data2()` results relative to enabled and exported channels

| Enabled channels | Exported channels | Correct command                          |
| ---------------- | ----------------- | ---------------------------------------- |
| Analog           | Analog            | ' ' (None)                               |
|                  | Digital           | Wrong combination                        |
|                  | Both              | Wrong combination                        |
|                  |                   |                                          |
| Digital          | Analog            | Wrong combination                        |
|                  | Digital           | ' ' (None)                               |
|                  | Both              | Wrong combination                        |
|                  |                   |                                          |
| Both             | Analog            | ANALOG_ONLY (ANALOG_AND_DIGITAL also works) |
|                  | Digital           | DIGITAL_ONLY                             |
|                  | Both              | ANALOG_AND_DIGITAL                       |


## Examples

**Analog** enabled and **analog** exported:
```python
s.set_active_channels([], [2, 3])
s.export_data2(filename, digital_channels=None, analog_channels=[3])
```
**Digital** enabled and **digital** exported:
```python
s.set_active_channels([0, 1], [])
s.export_data2(filename, digital_channels=[0], analog_channels=None)
```

**Both** enabled
```python
s.set_active_channels([0, 1], [2, 3])
```
and:
- **analog** exported:
  ```python
  s.export_data2(filename, digital_channels=None, analog_channels=[3])
  ```

- **digital** exported:

  ```python
  s.export_data2(filename, digital_channels=[0], analog_channels=None)
  ```

- **both** exported
  ``` python
  s.export_data2(filename, digital_channels=[0], analog_channels=[3])
  ```