### PR TITLE
Added optional args to forward to Logic

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -140,6 +140,7 @@ class Saleae():
 				p = os.path.join("C:", os.sep, "Program Files", "Saleae Inc", "Logic.exe")
 				if not os.path.exists(p):
 					p = os.path.join("C:", os.sep, "Program Files", "Saleae LLC", "Logic.exe")
+			p = '"{}"'.format(p)
 			if args is not None:
 				p += ' ' + args
 			os.system(p)


### PR DESCRIPTION
This allows the user to pass command line arguments to the logic executable, both through the Saleae constructor and through the launch_logic function.

useful arguments:
`-disablepopups` disables blocking popups in the application, like the "could not keep up" error.
`-uploaderrors` automatically accept and close the "upload error reports" dialog, if restarting the application after a crash.

example:

```
import saleae
s = saleae.Saleae('127.0.0.1', 10429, False, '-disablepopups -uploaderrors')
# or
Saleae.launch_logic(args='-disablepopups -uploaderrors')
```

Tested on MacOS!

TODO:
- [x] Test on Windows
- [x] Test on Linux