### PR TITLE
added EXIT command, to cleanly close Logic

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -1035,6 +1035,10 @@ class Saleae():
 		resp = self._finish()
 		return resp.strip().upper() == 'TRUE'
 
+	def exit(self):
+		'''close the software gracefully'''
+		self._cmd('EXIT')
+
 
 def demo(host='localhost', port=10429):
 	'''A demonstration / usage guide that mirrors Saleae's C# demo'''


### PR DESCRIPTION
documented here:
https://github.com/saleae/SaleaeSocketApi/blob/master/Doc/Logic%20Socket%20API%20Users%20Guide.md#exit

Not sure when it was added, but it's been in there since at least 1.2.10, which includes the current production release, 1.2.18.