### PR TITLE
Fix enum34 not required for Python 3.4 and above

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ exec(open(os.path.join('saleae', 'version.py')).read())
 
 requires = [
 		'future',
-		'enum34',
+		'enum34;python_version<"3.4"',
 		'psutil',
 		]
 


### PR DESCRIPTION
Modify requirements in setup.py to not install enum34 when not needed. Reason: enum34 is a backport of Python 3.4 Enum for Python 3.3 and older so installing it for Python 3.4 and above can cause issues with other packages using the enum. Closes #57