### PR TITLE
Fix: launching windows blocks execution

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -141,13 +141,12 @@ class Saleae():
 				p = os.path.join("C:", os.sep, "Program Files", "Saleae Inc", "Logic.exe")
 				if not os.path.exists(p):
 					p = os.path.join("C:", os.sep, "Program Files", "Saleae LLC", "Logic.exe")
-			p = '"{}"'.format(p)
 
 			popen_args = [p]
 			if args is not None:
 				popen_args.extend(args.split())
 
-			subprocess.Popen([popen_args])
+			subprocess.Popen(popen_args)
 		else:
 			raise NotImplementedError("Unknown platform " + platform.system())
 

--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -96,7 +96,7 @@ class Saleae():
 		pass
 
 	@staticmethod
-	def launch_logic(timeout=5, quiet=False, logic_path=None, args=None):
+	def launch_logic(timeout=15, quiet=False, logic_path=None, args=None):
 		'''Attempts to open Saleae Logic software
 
 		:param timeout: Time in seconds to wait for the Logic software to launch
@@ -109,6 +109,7 @@ class Saleae():
 			Examples:
 			-disablepopups (suppress notifications)
 			-uploaderrors (accept the upload errors dialog and close it)
+		:returns True if the Logic software launched and accepted a socket connection within the timeout
 		'''
 		if platform.system() == 'Darwin':
 			logic_path = logic_path or '/Applications/Logic.app'
@@ -152,13 +153,15 @@ class Saleae():
 
 		# Try to intelligently wait for Logic to be ready, but can't wait
 		# forever because user may not have enabled the scripting server
-		while timeout > 0:
+		connection_start = time.time()
+		while time.time() < (connection_start + timeout):
 			with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
 				if sock.connect_ex(('localhost', 10429)) == 0:
-					break
+					print('connection detected after {} seconds'.format(time.time()-connection_start))
+					return True
 			log.debug('launch_logic: port not yet open, sleeping 1s')
 			time.sleep(1)
-			timeout -= 1
+		return False
 
 	@staticmethod
 	def _list_logic_candidates():

--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -26,6 +26,7 @@ import socket
 import sys
 import time
 import warnings
+import subprocess
 
 # Py2k compat. This isn't actually 1:1, but is sufficient for our purposes
 try:
@@ -141,9 +142,12 @@ class Saleae():
 				if not os.path.exists(p):
 					p = os.path.join("C:", os.sep, "Program Files", "Saleae LLC", "Logic.exe")
 			p = '"{}"'.format(p)
+
+			popen_args = [p]
 			if args is not None:
-				p += ' ' + args
-			os.system(p)
+				popen_args.extend(args.split())
+
+			subprocess.Popen([popen_args])
 		else:
 			raise NotImplementedError("Unknown platform " + platform.system())
 


### PR DESCRIPTION
🤦 My last PR to add command line args for launching logic used `os.system(p)`, which blocks until Logic exits. Not sure how I could missed that, I could have swore I tested it several times.

This changes it to `subprocess.Popen`