### PR TITLE
Miscellaneous improvements

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -96,7 +96,7 @@ class Saleae():
 		pass
 
 	@staticmethod
-	def launch_logic(timeout=15, quiet=False, logic_path=None, args=None):
+	def launch_logic(timeout=15, quiet=False, host='localhost', port=10429, logic_path=None, args=None):
 		'''Attempts to open Saleae Logic software
 
 		:param timeout: Time in seconds to wait for the Logic software to launch
@@ -156,7 +156,7 @@ class Saleae():
 		connection_start = time.time()
 		while time.time() < (connection_start + timeout):
 			with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
-				if sock.connect_ex(('localhost', 10429)) == 0:
+				if sock.connect_ex((host, port)) == 0:
 					log.info('connection detected after {} seconds'.format(time.time()-connection_start))
 					return True
 			log.debug('launch_logic: port not yet open, sleeping 1s')

--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -12,7 +12,7 @@ from builtins import (bytes, dict, int, list, object, range, str, ascii, chr,
 
 import logging
 log = logging.getLogger(__name__)
-#logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO)
 
 import bisect
 import contextlib
@@ -157,7 +157,7 @@ class Saleae():
 		while time.time() < (connection_start + timeout):
 			with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
 				if sock.connect_ex(('localhost', 10429)) == 0:
-					print('connection detected after {} seconds'.format(time.time()-connection_start))
+					log.info('connection detected after {} seconds'.format(time.time()-connection_start))
 					return True
 			log.debug('launch_logic: port not yet open, sleeping 1s')
 			time.sleep(1)
@@ -211,16 +211,16 @@ class Saleae():
 			self._s.connect((host, port))
 		except ConnectionRefusedError:
 			log.info("Could not connect to Logic software, attempting to launch it now")
-			Saleae.launch_logic(quiet=quiet, args=args)
+			Saleae.launch_logic(quiet=quiet, host=host, port=port, args=args)
 
 		try:
 			self._s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 			self._s.connect((host, port))
 		except ConnectionRefusedError:
-			print("Failed to connect to saleae at {}:{}".format(host, port))
-			print("")
-			print("Did you remember to 'Enable scripting socket server' (see README)?")
-			print("")
+			log.error("Failed to connect to saleae at {}:{}".format(host, port))
+			log.info("")
+			log.info("Did you remember to 'Enable scripting socket server' (see README)?")
+			log.info("")
 			raise
 		log.info("Connected.")
 		self._rxbuf = ''


### PR DESCRIPTION
I would like contribute with the following: 

- There are only few parts where `print()` is used to communicate what's happening within the library as compared to `log.info()`. I suggest to enable logger with `INFO` defaults instead of `DEBUG`, so in that way the library can uniformly communicate throughout the logger. 
- When application is not started yet, the socket host and port can change from default. Then, instead of forcing this to default, let's allow developer to choose at which socket host and port is the application listening, otherwise, let's propagate the defaults values coming `__init__()`. Does this make sense to you? 

Let me know your thoughts. I already bumped to upcoming version as well. 