### PR TITLE
Implement Saleae.get_num_samples

### DIFF
--- a/saleae/saleae.py
+++ b/saleae/saleae.py
@@ -340,6 +340,15 @@ class Saleae():
 		'''
 		self._cmd('SET_NUM_SAMPLES, {:d}'.format(int(samples)))
 
+	def get_num_samples(self):
+		'''
+		>>> s.set_num_samples(1e6)
+		>>> s.get_num_samples()
+		1000000
+		'''
+		samples = self._cmd('GET_NUM_SAMPLES')
+		return int(samples.rstrip('\n'))
+
 	def set_capture_seconds(self, seconds):
 		'''Set the capture duration to a length of time.
 


### PR DESCRIPTION
The ``get_num_samples`` method is mentioned in the [Logic Socket API Users Guide](https://github.com/saleae/SaleaeSocketApi/blob/master/Doc/Logic%20Socket%20API%20Users%20Guide.md) but not implemented.

I've left out documentation, feel free to update the docstring.